### PR TITLE
Address hidden errors in CAQR

### DIFF
--- a/alg/QR/qr_2d/qr_2d.cxx
+++ b/alg/QR/qr_2d/qr_2d.cxx
@@ -247,7 +247,7 @@ void upd_A( double const *  Ybuf,
   } else {
     if (W_is_T) cT=W;
     else { 
-      comp_bcast_T_from_W(b, W, Ybuf, lda_Y, &T, pv->rcol+pv->rrow*pv->crow.np, (pv->rrow==pv->ccol.rank) & (pv->rcol==pv->crow.rank), pv->cworld.cm);
+      comp_bcast_T_from_W(b, W, Ybuf, lda_Y, &T, pv->rrow+pv->rcol*pv->ccol.np, (pv->rrow==pv->ccol.rank) & (pv->rcol==pv->crow.rank), pv->cworld.cm);
       cT = T;
     }
   }

--- a/alg/QR/qr_2d/qr_2d.cxx
+++ b/alg/QR/qr_2d/qr_2d.cxx
@@ -587,6 +587,7 @@ void QR_2D_pipe(double * A,
 
       pv->rrow = (pv->rrow+1) % pv->ccol.np;
       pv->rcol = (pv->rcol+1) % pv->crow.np;
+      free(new_Y);
       QR_2D_pipe(A, lda_A, 
                  m-b, k-b, b, pv, NULL, 0, NULL, NULL);
     } else {


### PR DESCRIPTION
The memory leak was found only when tuning across many different algorithmic configurations.

The logical processor grid root calculation was found when placing asserts on the return values of LAPACK routines. The modified line in question originally used a row-major stride order rather than a column-order stride order across the processors in a 2D grid, which conflicts with the way the 2D grids are configured in the bench files.